### PR TITLE
Update Bloc to fix DNU on unregister

### DIFF
--- a/src/BaselineOfMyg/BaselineOfMyg.class.st
+++ b/src/BaselineOfMyg/BaselineOfMyg.class.st
@@ -14,7 +14,7 @@ BaselineOfMyg >> baseline: spec [
 
 	spec
 		baseline: 'Bloc'
-		with: [ spec repository: 'github://pharo-graphics/Bloc:v2.0.0-alpha/src' ].
+		with: [ spec repository: 'github://pharo-graphics/Bloc:34b48bbf1d1c1776c5abe5d44e5a11165a17dd60/src' ].
 
 
 	spec baseline: 'ContainersArray2D' with: [

--- a/src/BaselineOfMyg/BaselineOfMyg.class.st
+++ b/src/BaselineOfMyg/BaselineOfMyg.class.st
@@ -10,11 +10,11 @@ BaselineOfMyg >> baseline: spec [
 	<baseline>
 	spec
 		baseline: 'Toplo'
-		with: [ spec repository: 'github://plantec/Toplo:573bdc3e26b9a93954889db16fed838452034a16/src' ].
+		with: [ spec repository: 'github://plantec/Toplo:8daf74a/src' ].
 
 	spec
 		baseline: 'Bloc'
-		with: [ spec repository: 'github://pharo-graphics/Bloc:05e5b0e385811719537f8cd89966b150a07be985/src' ].
+		with: [ spec repository: 'github://pharo-graphics/Bloc:v2.0.0-alpha/src' ].
 
 
 	spec baseline: 'ContainersArray2D' with: [


### PR DESCRIPTION
Alain reported and fixed issue https://github.com/Ducasse/Myg/issues/9 in https://github.com/pharo-graphics/Bloc/issues/331

This PR changes the hash of Bloc to include this Alain's fix, and also updates Toplo so it should work with #7 and #8.

Try this PR with:
```
Metacello new
 baseline: 'Myg';
 repository: 'github://Ducasse/Myg:martinUpdateDeps1/src';
 onConflictUseIncoming;
 load.

MineSweeper open.
Takuzu open.
Sokoban open.
```