### PR TITLE
Refactor null states SameGame

### DIFF
--- a/src/Myg-SameGame/SGAbstractState.class.st
+++ b/src/Myg-SameGame/SGAbstractState.class.st
@@ -1,0 +1,26 @@
+Class {
+	#name : 'SGAbstractState',
+	#superclass : 'Object',
+	#classInstVars : [
+		'uniqueInstance'
+	],
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
+}
+
+{ #category : 'accessing' }
+SGAbstractState class >> uniqueInstance [
+
+	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
+]
+
+{ #category : 'testing' }
+SGAbstractState >> isNull [
+	^ false
+]
+
+{ #category : 'testing' }
+SGAbstractState >> literal [
+	self subclassResponsibility 
+]

--- a/src/Myg-SameGame/SGBlueState.class.st
+++ b/src/Myg-SameGame/SGBlueState.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SGBlueState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGBlueState',
+	#superclass : 'SGNullState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBlueState >> backgroundRepresentation [
 
 	^ Color lightBlue
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBlueState >> isNull [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SGBlueState >> literal [
 
 	^ 'B'

--- a/src/Myg-SameGame/SGBlueState.class.st
+++ b/src/Myg-SameGame/SGBlueState.class.st
@@ -1,22 +1,18 @@
 Class {
-	#name : #SGBlueState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGBlueState',
+	#superclass : 'SGAbstractState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBlueState >> backgroundRepresentation [
 
 	^ Color lightBlue
 ]
 
-{ #category : #accessing }
-SGBlueState >> isNull [
-
-	^ false
-]
-
-{ #category : #testing }
+{ #category : 'testing' }
 SGBlueState >> literal [
 
 	^ 'B'

--- a/src/Myg-SameGame/SGBoard.class.st
+++ b/src/Myg-SameGame/SGBoard.class.st
@@ -1,38 +1,40 @@
 Class {
-	#name : #SGBoard,
-	#superclass : #MygBoard,
+	#name : 'SGBoard',
+	#superclass : 'MygBoard',
 	#instVars : [
 		'game',
 		'hitList'
 	],
-	#category : #'Myg-SameGame-Model'
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #compute }
+{ #category : 'compute' }
 SGBoard >> boxAt: aPoint [
 
 	^ self grid at: aPoint x @ aPoint y
 ]
 
-{ #category : #compute }
+{ #category : 'compute' }
 SGBoard >> calculePoint [
 
 	^ hitList size * hitList size
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoard >> game [
 
 	^ game
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoard >> game: aGame [
 
 	game := aGame
 ]
 
-{ #category : #reorganize }
+{ #category : 'reorganize' }
 SGBoard >> generateGridWidth: width height: height [
 
 	| array2D |
@@ -43,7 +45,7 @@ SGBoard >> generateGridWidth: width height: height [
 	self configureGrid: array2D
 ]
 
-{ #category : #hit }
+{ #category : 'hit' }
 SGBoard >> hitBox: aBox [
 
 	aBox hasNullState ifTrue: [ ^ self ].
@@ -60,7 +62,7 @@ SGBoard >> hitBox: aBox [
 	self reorganizeForEmptyColumn
 ]
 
-{ #category : #hit }
+{ #category : 'hit' }
 SGBoard >> hitBoxOnx: x y: y [
 
 	(self grid at: x @ y) hasNullState ifTrue: [ ^ self ].
@@ -77,13 +79,13 @@ SGBoard >> hitBoxOnx: x y: y [
 	self reorganizeForEmptyColumn
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoard >> hitList [ 
 
 	^ hitList 
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SGBoard >> initialize [
 
 	super initialize.
@@ -92,7 +94,7 @@ SGBoard >> initialize [
 	"stock les cases touchées"
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoard >> isColumnEmpty: x [
 
 	1 to: self grid height do: [ :i |
@@ -100,7 +102,7 @@ SGBoard >> isColumnEmpty: x [
 	^ true
 ]
 
-{ #category : #'random subclass instance creation' }
+{ #category : 'random subclass instance creation' }
 SGBoard >> randomBox [
 
 	| states |
@@ -112,7 +114,7 @@ SGBoard >> randomBox [
 	^ SGBox withState: states atRandom uniqueInstance 
 ]
 
-{ #category : #reorganize }
+{ #category : 'reorganize' }
 SGBoard >> reorganizeColumn: x [
 
 	| col newCol |
@@ -123,7 +125,7 @@ SGBoard >> reorganizeColumn: x [
 	(col at: j) state: SGNullState uniqueInstance ]
 ]
 
-{ #category : #reorganize }
+{ #category : 'reorganize' }
 SGBoard >> reorganizeForEmptyColumn [
 
 	| cpt |
@@ -135,7 +137,7 @@ SGBoard >> reorganizeForEmptyColumn [
 			cpt := cpt + 1 ] ]
 ]
 
-{ #category : #compute }
+{ #category : 'compute' }
 SGBoard >> switchBox: aPoint1 with: aPoint2 [
 
 	| box1 box2 tmpState |
@@ -148,7 +150,7 @@ SGBoard >> switchBox: aPoint1 with: aPoint2 [
 	box2 state: tmpState 
 ]
 
-{ #category : #compute }
+{ #category : 'compute' }
 SGBoard >> switchColumn: firstColumn withColumn: secondColumn [
 
 	1 to: self grid height do: [ :i |

--- a/src/Myg-SameGame/SGBoardElement.class.st
+++ b/src/Myg-SameGame/SGBoardElement.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #SGBoardElement,
-	#superclass : #BlElement,
+	#name : 'SGBoardElement',
+	#superclass : 'BlElement',
 	#instVars : [
 		'grid',
 		'sameGameBoard'
 	],
-	#category : #'Myg-SameGame-UI'
+	#category : 'Myg-SameGame-UI',
+	#package : 'Myg-SameGame',
+	#tag : 'UI'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoardElement >> grid [
 
 	^ grid
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoardElement >> grid: aSameGameBoardGrid [
 
 	grid := CTNewArray2D
@@ -32,7 +34,7 @@ SGBoardElement >> grid: aSameGameBoardGrid [
 	self setGridLayout: aSameGameBoardGrid width
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SGBoardElement >> setGridLayout: width [
 
 	self layout: (BlGridLayout horizontal

--- a/src/Myg-SameGame/SGBoardElementTest.class.st
+++ b/src/Myg-SameGame/SGBoardElementTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #SGBoardElementTest,
-	#superclass : #TestCase,
+	#name : 'SGBoardElementTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'board',
 		'graphicBoard'
 	],
-	#category : #'Myg-SameGame-UI-Tests'
+	#category : 'Myg-SameGame-UI-Tests',
+	#package : 'Myg-SameGame',
+	#tag : 'UI-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SGBoardElementTest >> setUp [
 
 	super setUp.
@@ -37,7 +39,7 @@ SGBoardElementTest >> setUp [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SGBoardElementTest >> testClickOn2BlueBoxesColumnRearrange [
 	
 	board hitBoxOnx: 1 y: 1.
@@ -53,7 +55,7 @@ SGBoardElementTest >> testClickOn2BlueBoxesColumnRearrange [
 		equals: Color gray.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SGBoardElementTest >> testClickOn3YellowBoxesSwitchEmptyColumn [
 
 	board hitBoxOnx: 2 y: 1.
@@ -78,7 +80,7 @@ SGBoardElementTest >> testClickOn3YellowBoxesSwitchEmptyColumn [
 		equals: Color gray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SGBoardElementTest >> testClickOnIsolatedBoxNothingChanges [
 
 		self
@@ -92,7 +94,7 @@ SGBoardElementTest >> testClickOnIsolatedBoxNothingChanges [
 		equals: Color lightRed.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SGBoardElementTest >> testClickOnNullNothingChanges [
 
 		self
@@ -106,7 +108,7 @@ SGBoardElementTest >> testClickOnNullNothingChanges [
 		equals: Color gray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SGBoardElementTest >> testExchangeCase [
 
 	self
@@ -128,7 +130,7 @@ self
 		equals: Color lightBlue.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SGBoardElementTest >> testGridSetUp [
 
 	self

--- a/src/Myg-SameGame/SGBox.class.st
+++ b/src/Myg-SameGame/SGBox.class.st
@@ -1,62 +1,64 @@
 Class {
-	#name : #SGBox,
-	#superclass : #MygAbstractBox,
+	#name : 'SGBox',
+	#superclass : 'MygAbstractBox',
 	#instVars : [
 		'state',
 		'announcer'
 	],
-	#category : #'Myg-SameGame-Model'
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #constants }
+{ #category : 'constants' }
 SGBox class >> blue [ 
 
 	^ self withState: SGBlueState uniqueInstance 
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 SGBox class >> green [
 
 	^ self withState: SGGreenState uniqueInstance
 ]
 
-{ #category : #factory }
+{ #category : 'factory' }
 SGBox class >> null [
 
 	^ self withState: SGNullState uniqueInstance 
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 SGBox class >> red [
 
 	^ self withState: SGRedState uniqueInstance
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 SGBox class >> withState: aState [ 
 
 	^ self new state: aState
 ]
 
-{ #category : #constants }
+{ #category : 'constants' }
 SGBox class >> yellow [
 
 	^ self withState: SGYellowState uniqueInstance
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBox >> announcer [
 
 	^ announcer ifNil: [ announcer := Announcer new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBox >> backgroundRepresentation [
 
 	^ self state backgroundRepresentation 
 ]
 
-{ #category : #clicking }
+{ #category : 'clicking' }
 SGBox >> checkAndPropagateOnX: x y: y [
 
 	| case |
@@ -64,32 +66,32 @@ SGBox >> checkAndPropagateOnX: x y: y [
 	case state = self state ifTrue: [ case propagateClick ]
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 SGBox >> click [
 
 	self board hitBox: self
 ]
 
-{ #category : #'drawing - general' }
+{ #category : 'drawing - general' }
 SGBox >> draw: drawer [
 
 	(drawer grid at: self x @ self y) background:
 		self backgroundRepresentation
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SGBox >> hasNullState [ 
 
 	^ self state isNull
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBox >> literal [ 
 
 	^ state literal
 ]
 
-{ #category : #clicking }
+{ #category : 'clicking' }
 SGBox >> propagateClick [
 
 	| x y |
@@ -105,13 +107,13 @@ SGBox >> propagateClick [
 		self checkAndPropagateOnX: x y: y + 1 ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBox >> state [
 
 	^ state 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBox >> state: aState [
 	"(aState class inheritsFrom: SGNullState) ifFalse: [ self halt ]."
 
@@ -120,13 +122,13 @@ SGBox >> state: aState [
 	self announcer announce: SGStateChangedAnnouncement new.
 ]
 
-{ #category : #'accessing - structure variables' }
+{ #category : 'accessing - structure variables' }
 SGBox >> x [
 
 	^ position x
 ]
 
-{ #category : #'accessing - structure variables' }
+{ #category : 'accessing - structure variables' }
 SGBox >> y [
 
 	^ position y

--- a/src/Myg-SameGame/SGBoxElement.class.st
+++ b/src/Myg-SameGame/SGBoxElement.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #SGBoxElement,
-	#superclass : #BlElement,
+	#name : 'SGBoxElement',
+	#superclass : 'BlElement',
 	#instVars : [
 		'gridPosition',
 		'board',
 		'box'
 	],
-	#category : #'Myg-SameGame-UI'
+	#category : 'Myg-SameGame-UI',
+	#package : 'Myg-SameGame',
+	#tag : 'UI'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement class >> createWithBox: aSGBox [
 
 	^ self new
@@ -18,25 +20,25 @@ SGBoxElement class >> createWithBox: aSGBox [
 		yourself
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement >> board [
 
 	^ board
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement >> board: aSGBoardElement [
 
 	board := aSGBoardElement
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement >> box [ 
 	
 	^ box
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement >> box: aSGBox [ 
 
 	box := aSGBox.
@@ -44,25 +46,25 @@ SGBoxElement >> box: aSGBox [
 	self initializeAnnouncements
 ]
 
-{ #category : #public }
+{ #category : 'public' }
 SGBoxElement >> click [
 
 	self box click
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement >> gridPosition [
 
 	^ gridPosition
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGBoxElement >> gridPosition: aPosition [
 
 	gridPosition := aPosition
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SGBoxElement >> initialize [
 
 	super initialize.
@@ -75,13 +77,13 @@ SGBoxElement >> initialize [
 	self addEventHandlerOn: BlClickEvent do: [ :anEvent | self click ]
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SGBoxElement >> initializeAnnouncements [ 
 
 	self box announcer when: SGStateChangedAnnouncement send: #updateBackgroundColor to: self
 ]
 
-{ #category : #'change reporting' }
+{ #category : 'change reporting' }
 SGBoxElement >> updateBackgroundColor [
 
 	^ self background: self box backgroundRepresentation

--- a/src/Myg-SameGame/SGGame.class.st
+++ b/src/Myg-SameGame/SGGame.class.st
@@ -1,45 +1,47 @@
 Class {
-	#name : #SGGame,
-	#superclass : #Object,
+	#name : 'SGGame',
+	#superclass : 'Object',
 	#instVars : [
 		'board',
 		'points'
 	],
-	#category : #'Myg-SameGame-Model'
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGame >> addPoints: numberOfPoints [
 
 	points := points + numberOfPoints
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGame >> grid [
 
 	^ board
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGame >> grid: aBoard [
 
 	board := aBoard
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 SGGame >> initialize [
 
 	super initialize.
 	self points: 0
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGame >> points [
 
 	^ points
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGame >> points: numberOfPoints [
 
 	points := numberOfPoints

--- a/src/Myg-SameGame/SGGreenState.class.st
+++ b/src/Myg-SameGame/SGGreenState.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SGGreenState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGGreenState',
+	#superclass : 'SGNullState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGreenState >> backgroundRepresentation [
 
 	^ Color lightGreen 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGreenState >> isNull [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SGGreenState >> literal [
 
 	^ 'G'

--- a/src/Myg-SameGame/SGGreenState.class.st
+++ b/src/Myg-SameGame/SGGreenState.class.st
@@ -1,22 +1,18 @@
 Class {
-	#name : #SGGreenState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGGreenState',
+	#superclass : 'SGAbstractState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGGreenState >> backgroundRepresentation [
 
 	^ Color lightGreen 
 ]
 
-{ #category : #accessing }
-SGGreenState >> isNull [
-
-	^ false
-]
-
-{ #category : #testing }
+{ #category : 'testing' }
 SGGreenState >> literal [
 
 	^ 'G'

--- a/src/Myg-SameGame/SGNullState.class.st
+++ b/src/Myg-SameGame/SGNullState.class.st
@@ -6,33 +6,35 @@ I have the responsabilities of my coordinates
 I am part of a Board of a Same Game
 "
 Class {
-	#name : #SGNullState,
-	#superclass : #Object,
+	#name : 'SGNullState',
+	#superclass : 'Object',
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : #'Myg-SameGame-Model'
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState class >> uniqueInstance [
 
 	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState >> backgroundRepresentation [
 
 	^ Color gray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState >> isNull [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState >> literal [
 
 	^ 'N'

--- a/src/Myg-SameGame/SGNullState.class.st
+++ b/src/Myg-SameGame/SGNullState.class.st
@@ -6,33 +6,26 @@ I have the responsabilities of my coordinates
 I am part of a Board of a Same Game
 "
 Class {
-	#name : #SGNullState,
-	#superclass : #Object,
-	#classInstVars : [
-		'uniqueInstance'
-	],
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGNullState',
+	#superclass : 'SGAbstractState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
-SGNullState class >> uniqueInstance [
-
-	^ uniqueInstance ifNil: [ uniqueInstance := self new ]
-]
-
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState >> backgroundRepresentation [
 
 	^ Color gray
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState >> isNull [
 
 	^ true
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGNullState >> literal [
 
 	^ 'N'

--- a/src/Myg-SameGame/SGRedState.class.st
+++ b/src/Myg-SameGame/SGRedState.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SGRedState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGRedState',
+	#superclass : 'SGNullState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGRedState >> backgroundRepresentation [
 
 	^ Color lightRed
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGRedState >> isNull [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SGRedState >> literal [
 
 	^ 'R'

--- a/src/Myg-SameGame/SGRedState.class.st
+++ b/src/Myg-SameGame/SGRedState.class.st
@@ -1,22 +1,18 @@
 Class {
-	#name : #SGRedState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGRedState',
+	#superclass : 'SGAbstractState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGRedState >> backgroundRepresentation [
 
 	^ Color lightRed
 ]
 
-{ #category : #accessing }
-SGRedState >> isNull [
-
-	^ false
-]
-
-{ #category : #testing }
+{ #category : 'testing' }
 SGRedState >> literal [
 
 	^ 'R'

--- a/src/Myg-SameGame/SGStateChangedAnnouncement.class.st
+++ b/src/Myg-SameGame/SGStateChangedAnnouncement.class.st
@@ -1,5 +1,7 @@
 Class {
-	#name : #SGStateChangedAnnouncement,
-	#superclass : #Announcement,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGStateChangedAnnouncement',
+	#superclass : 'Announcement',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }

--- a/src/Myg-SameGame/SGYellowState.class.st
+++ b/src/Myg-SameGame/SGYellowState.class.st
@@ -1,22 +1,24 @@
 Class {
-	#name : #SGYellowState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGYellowState',
+	#superclass : 'SGNullState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGYellowState >> backgroundRepresentation [
 
 	^ Color lightYellow
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGYellowState >> isNull [
 
 	^ false
 ]
 
-{ #category : #testing }
+{ #category : 'testing' }
 SGYellowState >> literal [
 
 	^ 'Y'

--- a/src/Myg-SameGame/SGYellowState.class.st
+++ b/src/Myg-SameGame/SGYellowState.class.st
@@ -1,22 +1,18 @@
 Class {
-	#name : #SGYellowState,
-	#superclass : #SGNullState,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SGYellowState',
+	#superclass : 'SGAbstractState',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 SGYellowState >> backgroundRepresentation [
 
 	^ Color lightYellow
 ]
 
-{ #category : #accessing }
-SGYellowState >> isNull [
-
-	^ false
-]
-
-{ #category : #testing }
+{ #category : 'testing' }
 SGYellowState >> literal [
 
 	^ 'Y'

--- a/src/Myg-SameGame/SameGame.class.st
+++ b/src/Myg-SameGame/SameGame.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #SameGame,
-	#superclass : #Object,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SameGame',
+	#superclass : 'Object',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SameGame class >> open [
 
 	<script>
@@ -22,6 +24,6 @@ SameGame class >> open [
 	space show
 ]
 
-{ #category : #'see class side' }
+{ #category : 'see class side' }
 SameGame >> seeClassSide [ 
 ]

--- a/src/Myg-SameGame/SameGame.class.st
+++ b/src/Myg-SameGame/SameGame.class.st
@@ -1,16 +1,18 @@
 Class {
-	#name : #SameGame,
-	#superclass : #Object,
-	#category : #'Myg-SameGame-Model'
+	#name : 'SameGame',
+	#superclass : 'Object',
+	#category : 'Myg-SameGame-Model',
+	#package : 'Myg-SameGame',
+	#tag : 'Model'
 }
 
-{ #category : #'instance creation' }
-SameGame class >> open [
+{ #category : 'instance creation' }
+SameGame class >> gameWithSize: size [
 
 	<script>
 	| board graphicBoard space |
 	board := SGBoard new game: SGGame new.
-	board generateGridWidth: 20 height: 20.
+	board generateGridWidth: size height: size.
 	graphicBoard := SGBoardElement new.
 	graphicBoard grid: board grid.
 
@@ -18,10 +20,22 @@ SameGame class >> open [
 	space title: 'SameGame'.
 	space root addChild: graphicBoard.
 	space extent: 1000 @ 1000.
-
-	space show
+	^ space
 ]
 
-{ #category : #'see class side' }
+{ #category : 'instance creation' }
+SameGame class >> open [
+	self openWithSize:20
+]
+
+{ #category : 'instance creation' }
+SameGame class >> openWithSize: size [
+
+	<script>
+
+	(self gameWithSize: size) show
+]
+
+{ #category : 'see class side' }
 SameGame >> seeClassSide [ 
 ]

--- a/src/Myg-SameGame/SameGameBoardElementTest.class.st
+++ b/src/Myg-SameGame/SameGameBoardElementTest.class.st
@@ -1,13 +1,15 @@
 Class {
-	#name : #SameGameBoardElementTest,
-	#superclass : #TestCase,
+	#name : 'SameGameBoardElementTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'board'
 	],
-	#category : #'Myg-SameGame-Model-Tests'
+	#category : 'Myg-SameGame-Model-Tests',
+	#package : 'Myg-SameGame',
+	#tag : 'Model-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SameGameBoardElementTest >> setUp [
 
 	super setUp.
@@ -32,7 +34,7 @@ SameGameBoardElementTest >> setUp [
 			 yourself).
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickAndCaseNothingAppend [
 
 	| board game graphicBoard |
@@ -64,7 +66,7 @@ SameGameBoardElementTest >> testClickAndCaseNothingAppend [
 	self assert: (board grid at: 1 @ 3) literal equals: 'B'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickAndMultipleCaseDisappear [
 
 	| board game graphicBoard |
@@ -97,7 +99,7 @@ SameGameBoardElementTest >> testClickAndMultipleCaseDisappear [
 	self assert: (board grid at: 1 @ 1) literal equals: 'B'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickAndOneColumnDisappear [
 
 	| board game graphicBoard |
@@ -135,7 +137,7 @@ SameGameBoardElementTest >> testClickAndOneColumnDisappear [
 	self assert: (board grid at: 2 @ 3) literal equals: 'G'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickOn2BlueBoxesColumnRearrange [
 
 	self assert: (board grid at: 1 @ 1) literal equals: 'B'.
@@ -161,7 +163,7 @@ SameGameBoardElementTest >> testClickOn2BlueBoxesColumnRearrange [
 	self assert: (board grid at: 3 @ 3) literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickOn3YellowBoxesSwitchEmptyColumn [
 
 	self assert: (board grid at: 1 @ 1) literal equals: 'B'.
@@ -187,7 +189,7 @@ SameGameBoardElementTest >> testClickOn3YellowBoxesSwitchEmptyColumn [
 	self assert: (board grid at: 3 @ 3) literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickOnBlueCase [
 
 	| board resGrid game graphicBoard resgraphicBoard |
@@ -226,7 +228,7 @@ SameGameBoardElementTest >> testClickOnBlueCase [
 		equals: (resGrid grid at: 2 @ 1) state
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickOnIsolatedBoxNothingChanges [
 
 	self assert: (board grid at: 1 @ 1) literal equals: 'B'.
@@ -252,7 +254,7 @@ SameGameBoardElementTest >> testClickOnIsolatedBoxNothingChanges [
 	self assert: (board grid at: 3 @ 3) literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testClickOnNullNothingChanges [
 
 	self assert: (board grid at: 1 @ 1) literal equals: 'B'.
@@ -278,7 +280,7 @@ SameGameBoardElementTest >> testClickOnNullNothingChanges [
 	self assert: (board grid at: 3 @ 3) literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testColonneIsEmpty [
 
 	| board game graphicBoard |
@@ -302,7 +304,7 @@ SameGameBoardElementTest >> testColonneIsEmpty [
 	self deny: (board isColumnEmpty: 2)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testExchangeCase [
 
 	| board case1 case2 game graphicBoard |
@@ -337,7 +339,7 @@ SameGameBoardElementTest >> testExchangeCase [
 	self assert: case2 literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testExchangeColonne [
 
 	| board game graphicBoard |
@@ -368,7 +370,7 @@ SameGameBoardElementTest >> testExchangeColonne [
 	self assert: (board boxAt: 2 @ 3) literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testReorganiseBoard [
 
 	| firstBoard game graphicBoard |
@@ -399,7 +401,7 @@ SameGameBoardElementTest >> testReorganiseBoard [
 	self assert: (firstBoard grid at: 1 @ 5) literal equals: 'N'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SameGameBoardElementTest >> testReorganiseWhenEmptyColonne [
 	"
 | B Y Y |        | Y Y N |

--- a/src/Myg-SameGame/SameGameTest.class.st
+++ b/src/Myg-SameGame/SameGameTest.class.st
@@ -5,3 +5,29 @@ Class {
 	#package : 'Myg-SameGame',
 	#tag : 'Model-Tests'
 }
+
+{ #category : 'tests' }
+SameGameTest >> testSameGameGameWithHeightReturnABoardWithTheExpectedSize [
+	"comment stating purpose of instance-side method"
+	"scope: class-variables  &  instance-variables"
+
+	| space board |
+	
+	space:=SameGame gameWithSize: 20.
+	board:= space root children first.
+	self assert: board grid height equals: 20.
+	
+]
+
+{ #category : 'tests' }
+SameGameTest >> testSameGameGameWithSizeReturnABoardWithTheExpectedSize [
+	"comment stating purpose of instance-side method"
+	"scope: class-variables  &  instance-variables"
+
+	| space board |
+	
+	space:=SameGame gameWithSize: 20.
+	board:= space root children first.
+	self assert: board grid width equals: 20.
+	
+]

--- a/src/Myg-SameGame/SameGameTest.class.st
+++ b/src/Myg-SameGame/SameGameTest.class.st
@@ -1,0 +1,7 @@
+Class {
+	#name : 'SameGameTest',
+	#superclass : 'TestCase',
+	#category : 'Myg-SameGame-Model-Tests',
+	#package : 'Myg-SameGame',
+	#tag : 'Model-Tests'
+}

--- a/src/Myg-SameGame/package.st
+++ b/src/Myg-SameGame/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Myg-SameGame' }
+Package { #name : 'Myg-SameGame' }


### PR DESCRIPTION
In SameGame, all states inherited from a null state. 
It mean that technically, every state is a null state.

I propose another hierarchy, with an abstract state as the parent of every other states (Included the null state)